### PR TITLE
Add device type to API /device

### DIFF
--- a/web/app/Device.php
+++ b/web/app/Device.php
@@ -21,9 +21,8 @@ class Device extends Model
 
     /**
      * Tables that are always joined
-     * Not necessary? Don't unterstand how that works :)
      */
-    //public $with = ['deviceType', 'traits'];
+    public $with = ['deviceType'];
 
     public function deviceType(){
         return $this->belongsTo('App\DeviceType', 'devicetype_id');

--- a/web/app/Http/Controllers/ApiV2/ApiV2.php
+++ b/web/app/Http/Controllers/ApiV2/ApiV2.php
@@ -54,6 +54,7 @@ class ApiV2 extends Controller
             return [
                 "device_id" => $device['device_id'],
                 "name" => $device['name'],
+                "type" => $device['device_type']['shortname']
             ];
         }, $devices);
 


### PR DESCRIPTION
I'm writing a mobile app to manage your gBridge devices.
It is useful for the devices list screen to show which device type it is next to its name, but the existing list endpoint only includes the name and the id. I'm changing that with this change